### PR TITLE
EFECTReport type and standards

### DIFF
--- a/src/python/env.yml
+++ b/src/python/env.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - python >= 3.8
   - numpy
+  - mkstd >= 0.0.3

--- a/src/python/env.yml
+++ b/src/python/env.yml
@@ -4,4 +4,6 @@ channels:
 dependencies:
   - python >= 3.8
   - numpy
-  - mkstd >= 0.0.4
+  - pip
+  - pip:
+    - mkstd >= 0.0.4

--- a/src/python/env.yml
+++ b/src/python/env.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - python >= 3.8
   - numpy
-  - mkstd >= 0.0.3
+  - mkstd >= 0.0.4

--- a/src/python/libssr/efect_report.py
+++ b/src/python/libssr/efect_report.py
@@ -11,17 +11,16 @@ from mkstd.standards import (
 )
 from mkstd.types.array import get_array_type
 
-
 # Stage 1: define a data model, then make standards from it.
 
 
-class SSRData(BaseModel):
-    """Data standard for libSSR."""
+class EFECTReport(BaseModel):
+    """Data standard for EFECT reports."""
 
-    ssr_level: int = Field(default=None, ge=0)
-    """SSR level"""
-    ssr_version: int = Field(default=None, ge=0)
-    """SSR version"""
+    efect_level: int = Field(default=None, ge=0)
+    """EFECT level"""
+    efect_version: int = Field(default=None, ge=0)
+    """EFECT version"""
 
     variable_names: list[str]
     """Variable names"""
@@ -61,7 +60,7 @@ class SSRData(BaseModel):
     """Significant figures of sample data"""
 
     @model_validator(mode="after")
-    def ensure_array_dimensions(self: SSRData) -> SSRData:
+    def ensure_array_dimensions(self: EFECTReport) -> EFECTReport:
         """Ensure that dependencies of array dimensions are satisfied."""
         # Keys are used in the expectation message.
         attr_measures = {
@@ -123,25 +122,25 @@ class SSRData(BaseModel):
         return self
 
 
-hdf5_standard = Hdf5Standard(model=SSRData)
+hdf5_standard = Hdf5Standard(model=EFECTReport)
 hdf5_standard.save_schema("standards/schema_hdf5.json")
 
-json_standard = JsonStandard(model=SSRData)
+json_standard = JsonStandard(model=EFECTReport)
 json_standard.save_schema("standards/schema.json")
 
-xml_standard = XmlStandard(model=SSRData)
+xml_standard = XmlStandard(model=EFECTReport)
 xml_standard.save_schema("standards/schema.xsd")
 
-yaml_standard = YamlStandard(model=SSRData)
+yaml_standard = YamlStandard(model=EFECTReport)
 yaml_standard.save_schema("standards/schema_yaml.json")
 
 # # Stage 2: use standards to validate/import/export data.
 # # Here, data are validated via `mkstd`. Third-party validators
 # # can also be used.
-# data = SSRData.parse_obj(
+# data = EFECTReport.parse_obj(
 #     {
-#         "ssr_level": 1,
-#         "ssr_version": 3,
+#         "efect_level": 1,
+#         "efect_version": 3,
 #         "variable_names": ["v1", "v2", "v3"],
 #         "simulation_times": np.linspace(0, 10, 4),
 #         "sample_size": 100000,
@@ -154,14 +153,14 @@ yaml_standard.save_schema("standards/schema_yaml.json")
 #     }
 # )
 # 
-# xml_standard.save_data(data=data, filename="output/data.xml")
-# data_xml = xml_standard.load_data(filename="output/data.xml")
+# xml_standard.save_data(data=data, filename="data/data.xml")
+# data_xml = xml_standard.load_data(filename="data/data.xml")
 # 
-# json_standard.save_data(data=data, filename="output/data.json")
-# data_json = json_standard.load_data(filename="output/data.json")
+# json_standard.save_data(data=data, filename="data/data.json")
+# data_json = json_standard.load_data(filename="data/data.json")
 # 
-# yaml_standard.save_data(data=data, filename="output/data.yaml")
-# data_yaml = yaml_standard.load_data(filename="output/data.yaml")
+# yaml_standard.save_data(data=data, filename="data/data.yaml")
+# data_yaml = yaml_standard.load_data(filename="data/data.yaml")
 # 
-# hdf5_standard.save_data(data=data, filename="output/data.hdf5")
-# data_hdf5 = hdf5_standard.load_data(filename="output/data.hdf5")
+# hdf5_standard.save_data(data=data, filename="data/data.hdf5")
+# data_hdf5 = hdf5_standard.load_data(filename="data/data.hdf5")

--- a/src/python/libssr/ssr_data.py
+++ b/src/python/libssr/ssr_data.py
@@ -18,9 +18,9 @@ from mkstd.types.array import get_array_type
 class SSRData(BaseModel):
     """Data standard for libSSR."""
 
-    ssr_level: int = Field(None, ge=0)
+    ssr_level: int = Field(default=None, ge=0)
     """SSR level"""
-    ssr_version: int = Field(None, ge=0)
+    ssr_version: int = Field(default=None, ge=0)
     """SSR version"""
 
     variable_names: list[str]
@@ -29,7 +29,7 @@ class SSRData(BaseModel):
         dtype=np.float64, dimensions=1, strict_dtype=True
     )
     """Simulation times"""
-    sample_size: int = Field(None, ge=1)
+    sample_size: int = Field(default=None, ge=1)
     """Sample size"""
 
     ecf_evals: get_array_type(
@@ -54,10 +54,10 @@ class SSRData(BaseModel):
 
     error_metric_mean: float
     """Error metric mean, from test for reproducibility"""
-    error_metric_stdev: float = Field(None, ge=0)
+    error_metric_stdev: float = Field(ge=0)
     """Error metric mean, from test for reproducibility"""
 
-    sig_figs: int = Field(None, ge=1)
+    sig_figs: int = Field(ge=1)
     """Significant figures of sample data"""
 
     @model_validator(mode="after")

--- a/src/python/libssr/ssr_data.py
+++ b/src/python/libssr/ssr_data.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field, model_validator
+
+from mkstd.standards import (
+    Hdf5Standard,
+    JsonStandard,
+    XmlStandard,
+    YamlStandard,
+)
+from mkstd.types.array import get_array_type
+
+
+# Stage 1: define a data model, then make standards from it.
+
+
+class SSRData(BaseModel):
+    """Data standard for libSSR."""
+
+    ssr_level: int = Field(None, ge=0)
+    """SSR level"""
+    ssr_version: int = Field(None, ge=0)
+    """SSR version"""
+
+    variable_names: list[str]
+    """Variable names"""
+    simulation_times: get_array_type(
+        dtype=np.float64, dimensions=1, strict_dtype=True
+    )
+    """Simulation times"""
+    sample_size: int = Field(None, ge=1)
+    """Sample size"""
+
+    ecf_evals: get_array_type(
+        dtype=np.float64, dimensions=4, strict_dtype=True
+    )
+    """ECF evaluations
+
+    - dim 0 is simulation time
+    - dim 1 is variable name
+    - dim 2 is evaluation index
+    - dim 3 is real/imaginary component
+    """
+
+    ecf_tval: get_array_type(dtype=np.float64, dimensions=2, strict_dtype=True)
+    """ECF evaluation final value
+
+    - dim 0 is simulation time
+    - dim 1 is variable name
+    """
+    ecf_nval: int = Field(None, ge=1)
+    """Number of evaluations per combination of simulation time and variable"""
+
+    error_metric_mean: float
+    """Error metric mean, from test for reproducibility"""
+    error_metric_stdev: float = Field(None, ge=0)
+    """Error metric mean, from test for reproducibility"""
+
+    sig_figs: int = Field(None, ge=1)
+    """Significant figures of sample data"""
+
+    @model_validator(mode="after")
+    def ensure_array_dimensions(self: SSRData) -> SSRData:
+        """Ensure that dependencies of array dimensions are satisfied."""
+        # Keys are used in the expectation message.
+        attr_measures = {
+            "the number of ": lambda x: len(x),
+            "": lambda x: x,
+        }
+        # These expectations have three elements:
+        # 1: array name and dimension
+        # 2: how to measure the expected value (a key of `attr_measures`)
+        # 3: the object that provides the expected value
+        expectations = [
+            (
+                ("ecf_evals", 0),
+                "the number of ",
+                "simulation_times",
+            ),
+            (
+                ("ecf_evals", 1),
+                "the number of ",
+                "variable_names",
+            ),
+            (
+                ("ecf_evals", 2),
+                "",
+                "ecf_nval",
+            ),
+            (
+                ("ecf_evals", 3),
+                "",
+                2,
+            ),
+            (
+                ("ecf_tval", 0),
+                "the number of ",
+                "simulation_times",
+            ),
+            (
+                ("ecf_tval", 1),
+                "the number of ",
+                "variable_names",
+            ),
+        ]
+        for (attr1, dim), attr0_kind, attr0 in expectations:
+            test_value = getattr(self, attr1).shape[dim]
+            if isinstance(attr0, str):
+                expected_value = attr_measures[attr0_kind](
+                    getattr(self, attr0)
+                )
+                current_expected_value = f" (currently `{expected_value}`)"
+            else:
+                expected_value = attr0
+                current_expected_value = ""
+            if test_value != expected_value:
+                raise ValueError(
+                    f"Dimension `{dim}` of `{attr1}` (currently "
+                    f"`{test_value}`) must equal {attr0_kind}`{attr0}`"
+                    f"{current_expected_value}."
+                )
+        return self
+
+
+hdf5_standard = Hdf5Standard(model=SSRData)
+hdf5_standard.save_schema("standards/schema_hdf5.json")
+
+json_standard = JsonStandard(model=SSRData)
+json_standard.save_schema("standards/schema.json")
+
+xml_standard = XmlStandard(model=SSRData)
+xml_standard.save_schema("standards/schema.xsd")
+
+yaml_standard = YamlStandard(model=SSRData)
+yaml_standard.save_schema("standards/schema_yaml.json")
+
+# # Stage 2: use standards to validate/import/export data.
+# # Here, data are validated via `mkstd`. Third-party validators
+# # can also be used.
+# data = SSRData.parse_obj(
+#     {
+#         "ssr_level": 1,
+#         "ssr_version": 3,
+#         "variable_names": ["v1", "v2", "v3"],
+#         "simulation_times": np.linspace(0, 10, 4),
+#         "sample_size": 100000,
+#         "ecf_evals": np.zeros((4, 3, 5, 2)),
+#         "ecf_tval": np.ones((4, 3)),
+#         "ecf_nval": 5,
+#         "error_metric_mean": 0.5,
+#         "error_metric_stdev": 0.2,
+#         "sig_figs": 5,
+#     }
+# )
+# 
+# xml_standard.save_data(data=data, filename="output/data.xml")
+# data_xml = xml_standard.load_data(filename="output/data.xml")
+# 
+# json_standard.save_data(data=data, filename="output/data.json")
+# data_json = json_standard.load_data(filename="output/data.json")
+# 
+# yaml_standard.save_data(data=data, filename="output/data.yaml")
+# data_yaml = yaml_standard.load_data(filename="output/data.yaml")
+# 
+# hdf5_standard.save_data(data=data, filename="output/data.hdf5")
+# data_hdf5 = hdf5_standard.load_data(filename="output/data.hdf5")

--- a/src/python/libssr/standards/schema.json
+++ b/src/python/libssr/standards/schema.json
@@ -49,13 +49,11 @@
             "type": "number"
         },
         "error_metric_stdev": {
-            "default": null,
             "minimum": 0.0,
             "title": "Error Metric Stdev",
             "type": "number"
         },
         "sig_figs": {
-            "default": null,
             "minimum": 1,
             "title": "Sig Figs",
             "type": "integer"
@@ -66,7 +64,9 @@
         "simulation_times",
         "ecf_evals",
         "ecf_tval",
-        "error_metric_mean"
+        "error_metric_mean",
+        "error_metric_stdev",
+        "sig_figs"
     ],
     "title": "SSRData",
     "type": "object"

--- a/src/python/libssr/standards/schema.json
+++ b/src/python/libssr/standards/schema.json
@@ -1,16 +1,16 @@
 {
-    "description": "Data standard for libSSR.",
+    "description": "Data standard for EFECT reports.",
     "properties": {
-        "ssr_level": {
+        "efect_level": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Level",
+            "title": "Efect Level",
             "type": "integer"
         },
-        "ssr_version": {
+        "efect_version": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Version",
+            "title": "Efect Version",
             "type": "integer"
         },
         "variable_names": {
@@ -68,6 +68,6 @@
         "error_metric_stdev",
         "sig_figs"
     ],
-    "title": "SSRData",
+    "title": "EFECTReport",
     "type": "object"
 }

--- a/src/python/libssr/standards/schema.json
+++ b/src/python/libssr/standards/schema.json
@@ -1,0 +1,73 @@
+{
+    "description": "Data standard for libSSR.",
+    "properties": {
+        "ssr_level": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Level",
+            "type": "integer"
+        },
+        "ssr_version": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Version",
+            "type": "integer"
+        },
+        "variable_names": {
+            "items": {
+                "type": "string"
+            },
+            "title": "Variable Names",
+            "type": "array"
+        },
+        "simulation_times": {
+            "title": "Simulation Times",
+            "type": "array"
+        },
+        "sample_size": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sample Size",
+            "type": "integer"
+        },
+        "ecf_evals": {
+            "title": "Ecf Evals",
+            "type": "array"
+        },
+        "ecf_tval": {
+            "title": "Ecf Tval",
+            "type": "array"
+        },
+        "ecf_nval": {
+            "default": null,
+            "minimum": 1,
+            "title": "Ecf Nval",
+            "type": "integer"
+        },
+        "error_metric_mean": {
+            "title": "Error Metric Mean",
+            "type": "number"
+        },
+        "error_metric_stdev": {
+            "default": null,
+            "minimum": 0.0,
+            "title": "Error Metric Stdev",
+            "type": "number"
+        },
+        "sig_figs": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sig Figs",
+            "type": "integer"
+        }
+    },
+    "required": [
+        "variable_names",
+        "simulation_times",
+        "ecf_evals",
+        "ecf_tval",
+        "error_metric_mean"
+    ],
+    "title": "SSRData",
+    "type": "object"
+}

--- a/src/python/libssr/standards/schema.xsd
+++ b/src/python/libssr/standards/schema.xsd
@@ -13,8 +13,8 @@
 	<xs:element name="ssrdata">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="ssr_level" type="xs:positiveInteger" minOccurs="0"/>
-				<xs:element name="ssr_version" type="xs:positiveInteger" minOccurs="0"/>
+				<xs:element name="efect_level" type="xs:positiveInteger" minOccurs="0"/>
+				<xs:element name="efect_version" type="xs:positiveInteger" minOccurs="0"/>
 				<xs:element name="variable_names" type="xs:string"/>
 				<xs:element name="simulation_times" type="xs:string"/>
 				<xs:element name="sample_size" type="integerGe1" minOccurs="0"/>

--- a/src/python/libssr/standards/schema.xsd
+++ b/src/python/libssr/standards/schema.xsd
@@ -13,14 +13,14 @@
 	<xs:element name="ssrdata">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="ssr_level" type="xs:positiveInteger"/>
-				<xs:element name="ssr_version" type="xs:positiveInteger"/>
+				<xs:element name="ssr_level" type="xs:positiveInteger" minOccurs="0"/>
+				<xs:element name="ssr_version" type="xs:positiveInteger" minOccurs="0"/>
 				<xs:element name="variable_names" type="xs:string"/>
 				<xs:element name="simulation_times" type="xs:string"/>
-				<xs:element name="sample_size" type="integerGe1"/>
+				<xs:element name="sample_size" type="integerGe1" minOccurs="0"/>
 				<xs:element name="ecf_evals" type="xs:string"/>
 				<xs:element name="ecf_tval" type="xs:string"/>
-				<xs:element name="ecf_nval" type="integerGe1"/>
+				<xs:element name="ecf_nval" type="integerGe1" minOccurs="0"/>
 				<xs:element name="error_metric_mean" type="xs:decimal"/>
 				<xs:element name="error_metric_stdev" type="decimalGe0"/>
 				<xs:element name="sig_figs" type="integerGe1"/>

--- a/src/python/libssr/standards/schema.xsd
+++ b/src/python/libssr/standards/schema.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="integerGe1">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="decimalGe0">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="ssrdata">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="ssr_level" type="xs:positiveInteger"/>
+				<xs:element name="ssr_version" type="xs:positiveInteger"/>
+				<xs:element name="variable_names" type="xs:string"/>
+				<xs:element name="simulation_times" type="xs:string"/>
+				<xs:element name="sample_size" type="integerGe1"/>
+				<xs:element name="ecf_evals" type="xs:string"/>
+				<xs:element name="ecf_tval" type="xs:string"/>
+				<xs:element name="ecf_nval" type="integerGe1"/>
+				<xs:element name="error_metric_mean" type="xs:decimal"/>
+				<xs:element name="error_metric_stdev" type="decimalGe0"/>
+				<xs:element name="sig_figs" type="integerGe1"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/python/libssr/standards/schema_hdf5.json
+++ b/src/python/libssr/standards/schema_hdf5.json
@@ -49,13 +49,11 @@
             "type": "number"
         },
         "error_metric_stdev": {
-            "default": null,
             "minimum": 0.0,
             "title": "Error Metric Stdev",
             "type": "number"
         },
         "sig_figs": {
-            "default": null,
             "minimum": 1,
             "title": "Sig Figs",
             "type": "integer"
@@ -66,7 +64,9 @@
         "simulation_times",
         "ecf_evals",
         "ecf_tval",
-        "error_metric_mean"
+        "error_metric_mean",
+        "error_metric_stdev",
+        "sig_figs"
     ],
     "title": "SSRData",
     "type": "object"

--- a/src/python/libssr/standards/schema_hdf5.json
+++ b/src/python/libssr/standards/schema_hdf5.json
@@ -1,16 +1,16 @@
 {
-    "description": "Data standard for libSSR.",
+    "description": "Data standard for EFECT reports.",
     "properties": {
-        "ssr_level": {
+        "efect_level": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Level",
+            "title": "Efect Level",
             "type": "integer"
         },
-        "ssr_version": {
+        "efect_version": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Version",
+            "title": "Efect Version",
             "type": "integer"
         },
         "variable_names": {
@@ -68,6 +68,6 @@
         "error_metric_stdev",
         "sig_figs"
     ],
-    "title": "SSRData",
+    "title": "EFECTReport",
     "type": "object"
 }

--- a/src/python/libssr/standards/schema_hdf5.json
+++ b/src/python/libssr/standards/schema_hdf5.json
@@ -1,0 +1,73 @@
+{
+    "description": "Data standard for libSSR.",
+    "properties": {
+        "ssr_level": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Level",
+            "type": "integer"
+        },
+        "ssr_version": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Version",
+            "type": "integer"
+        },
+        "variable_names": {
+            "items": {
+                "type": "string"
+            },
+            "title": "Variable Names",
+            "type": "array"
+        },
+        "simulation_times": {
+            "title": "Simulation Times",
+            "type": "array"
+        },
+        "sample_size": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sample Size",
+            "type": "integer"
+        },
+        "ecf_evals": {
+            "title": "Ecf Evals",
+            "type": "array"
+        },
+        "ecf_tval": {
+            "title": "Ecf Tval",
+            "type": "array"
+        },
+        "ecf_nval": {
+            "default": null,
+            "minimum": 1,
+            "title": "Ecf Nval",
+            "type": "integer"
+        },
+        "error_metric_mean": {
+            "title": "Error Metric Mean",
+            "type": "number"
+        },
+        "error_metric_stdev": {
+            "default": null,
+            "minimum": 0.0,
+            "title": "Error Metric Stdev",
+            "type": "number"
+        },
+        "sig_figs": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sig Figs",
+            "type": "integer"
+        }
+    },
+    "required": [
+        "variable_names",
+        "simulation_times",
+        "ecf_evals",
+        "ecf_tval",
+        "error_metric_mean"
+    ],
+    "title": "SSRData",
+    "type": "object"
+}

--- a/src/python/libssr/standards/schema_yaml.json
+++ b/src/python/libssr/standards/schema_yaml.json
@@ -49,13 +49,11 @@
             "type": "number"
         },
         "error_metric_stdev": {
-            "default": null,
             "minimum": 0.0,
             "title": "Error Metric Stdev",
             "type": "number"
         },
         "sig_figs": {
-            "default": null,
             "minimum": 1,
             "title": "Sig Figs",
             "type": "integer"
@@ -66,7 +64,9 @@
         "simulation_times",
         "ecf_evals",
         "ecf_tval",
-        "error_metric_mean"
+        "error_metric_mean",
+        "error_metric_stdev",
+        "sig_figs"
     ],
     "title": "SSRData",
     "type": "object"

--- a/src/python/libssr/standards/schema_yaml.json
+++ b/src/python/libssr/standards/schema_yaml.json
@@ -1,16 +1,16 @@
 {
-    "description": "Data standard for libSSR.",
+    "description": "Data standard for EFECT reports.",
     "properties": {
-        "ssr_level": {
+        "efect_level": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Level",
+            "title": "Efect Level",
             "type": "integer"
         },
-        "ssr_version": {
+        "efect_version": {
             "default": null,
             "minimum": 0,
-            "title": "Ssr Version",
+            "title": "Efect Version",
             "type": "integer"
         },
         "variable_names": {
@@ -68,6 +68,6 @@
         "error_metric_stdev",
         "sig_figs"
     ],
-    "title": "SSRData",
+    "title": "EFECTReport",
     "type": "object"
 }

--- a/src/python/libssr/standards/schema_yaml.json
+++ b/src/python/libssr/standards/schema_yaml.json
@@ -1,0 +1,73 @@
+{
+    "description": "Data standard for libSSR.",
+    "properties": {
+        "ssr_level": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Level",
+            "type": "integer"
+        },
+        "ssr_version": {
+            "default": null,
+            "minimum": 0,
+            "title": "Ssr Version",
+            "type": "integer"
+        },
+        "variable_names": {
+            "items": {
+                "type": "string"
+            },
+            "title": "Variable Names",
+            "type": "array"
+        },
+        "simulation_times": {
+            "title": "Simulation Times",
+            "type": "array"
+        },
+        "sample_size": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sample Size",
+            "type": "integer"
+        },
+        "ecf_evals": {
+            "title": "Ecf Evals",
+            "type": "array"
+        },
+        "ecf_tval": {
+            "title": "Ecf Tval",
+            "type": "array"
+        },
+        "ecf_nval": {
+            "default": null,
+            "minimum": 1,
+            "title": "Ecf Nval",
+            "type": "integer"
+        },
+        "error_metric_mean": {
+            "title": "Error Metric Mean",
+            "type": "number"
+        },
+        "error_metric_stdev": {
+            "default": null,
+            "minimum": 0.0,
+            "title": "Error Metric Stdev",
+            "type": "number"
+        },
+        "sig_figs": {
+            "default": null,
+            "minimum": 1,
+            "title": "Sig Figs",
+            "type": "integer"
+        }
+    },
+    "required": [
+        "variable_names",
+        "simulation_times",
+        "ecf_evals",
+        "ecf_tval",
+        "error_metric_mean"
+    ],
+    "title": "SSRData",
+    "type": "object"
+}

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,8 +1,7 @@
-import os
+from pathlib import Path
 from setuptools import setup
 
-__version__ = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                                'VERSION.txt')).readline().strip()
+__version__ = (Path(__file__).resolve().parents[2] / 'VERSION.txt').read_text()
 
 setup(
     name='libssr',
@@ -11,7 +10,7 @@ setup(
     author="T.J. Sego",
     author_email="timothy.sego@medicine.ufl.edu",
     python_requires='>=3.8',
-    install_requires=['numpy'],
+    install_requires=['numpy', 'mkstd >= 0.0.4'],
     packages=['libssr'],
     package_dir={'libssr': 'libssr'},
     package_data={'libssr': ['../../LICENSE', '../../VERSION.txt']}


### PR DESCRIPTION
Currently the example usage for `EFECTReport` is in a comment at the end of `efect_report.py`. This should be moved to the documentation somewhere, e.g. one of the example notebooks. Let me know if you have a suggestion.