### PR TITLE
Use mkstd[numpyv1] to ensure libroadrunner support

### DIFF
--- a/src/python/env.yml
+++ b/src/python/env.yml
@@ -6,4 +6,4 @@ dependencies:
   - numpy
   - pip
   - pip:
-    - mkstd >= 0.0.4
+    - "mkstd[numpyv1] >= 0.0.5"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -10,7 +10,7 @@ setup(
     author="T.J. Sego",
     author_email="timothy.sego@medicine.ufl.edu",
     python_requires='>=3.8',
-    install_requires=['numpy', 'mkstd >= 0.0.4'],
+    install_requires=['numpy', 'mkstd[numpyv1] >= 0.0.5'],
     packages=['libssr'],
     package_dir={'libssr': 'libssr'},
     package_data={'libssr': ['../../../LICENSE', '../../../VERSION.txt']}


### PR DESCRIPTION
This works for me via `pip install .`, but I didn't check with `conda`.